### PR TITLE
Feat: Migrate to json logging

### DIFF
--- a/wondyframe/Cargo.toml
+++ b/wondyframe/Cargo.toml
@@ -17,6 +17,6 @@ reqwest = { version = "0.13", default-features = false,  features = ["json", "qu
 serde = { version = "1.0", default-features = false,  features = ["derive"] }
 serde_json = "1.0"
 warframe = "9.0.1"
-log = "0.4.27"
-env_logger = "0.11.8"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] } 
 fuzzy-matcher = "0.3.7"

--- a/wondyframe/src/api/warframe_drops_client.rs
+++ b/wondyframe/src/api/warframe_drops_client.rs
@@ -1,5 +1,5 @@
-use log::info;
 use reqwest::Client;
+use tracing::info;
 
 use crate::models::drop_data::{
     blueprint_locations::BlueprintLocations, cetus_bounty_rewards::CetusBountyRewards,

--- a/wondyframe/src/commands/archimedea.rs
+++ b/wondyframe/src/commands/archimedea.rs
@@ -1,10 +1,10 @@
-use log::info;
 use poise::CreateReply;
 use serenity::all::{
     ButtonStyle, ComponentInteraction, ComponentInteractionCollector, CreateActionRow,
     CreateButton, CreateEmbed, CreateEmbedFooter, CreateInteractionResponse,
     CreateInteractionResponseMessage,
 };
+use tracing::info;
 
 use crate::api::warframe_client;
 use crate::enums::archimedea_type::ArchimedeaType;

--- a/wondyframe/src/commands/archon.rs
+++ b/wondyframe/src/commands/archon.rs
@@ -1,6 +1,6 @@
-use log::{error, info};
 use serenity::all::CreateEmbed;
 use serenity::all::CreateEmbedFooter;
+use tracing::{error, info};
 
 use crate::api::warframe_client;
 use crate::enums::colors::Colors;

--- a/wondyframe/src/commands/baro.rs
+++ b/wondyframe/src/commands/baro.rs
@@ -1,4 +1,3 @@
-use log::{error, info};
 use poise::CreateReply;
 use serenity::all::ActionRowComponent;
 use serenity::all::ButtonKind;
@@ -14,6 +13,7 @@ use serenity::all::CreateInteractionResponseMessage;
 use serenity::all::CreateSelectMenu;
 use serenity::all::CreateSelectMenuKind;
 use serenity::all::CreateSelectMenuOption;
+use tracing::{error, info};
 
 use crate::api::warframe_client;
 use crate::enums::colors::Colors;

--- a/wondyframe/src/commands/cetus.rs
+++ b/wondyframe/src/commands/cetus.rs
@@ -1,6 +1,6 @@
-use log::{error, info};
 use serenity::all::CreateEmbed;
 use serenity::all::CreateEmbedFooter;
+use tracing::{error, info};
 use warframe::worldstate::{TimedEvent, queryable::Cetus};
 
 use crate::enums::colors::Colors;

--- a/wondyframe/src/commands/deimos.rs
+++ b/wondyframe/src/commands/deimos.rs
@@ -1,6 +1,6 @@
-use log::{error, info};
 use serenity::all::CreateEmbed;
 use serenity::all::CreateEmbedFooter;
+use tracing::{error, info};
 use warframe::worldstate::{TimedEvent, queryable::CambionDrift};
 
 use crate::enums::colors::Colors;

--- a/wondyframe/src/commands/fissures.rs
+++ b/wondyframe/src/commands/fissures.rs
@@ -1,4 +1,3 @@
-use log::{error, info};
 use poise::CreateReply;
 use serenity::all::{
     ComponentInteraction, ComponentInteractionCollector, ComponentInteractionDataKind,
@@ -7,6 +6,7 @@ use serenity::all::{
     CreateSelectMenuOption,
 };
 use std::str::FromStr;
+use tracing::{error, info};
 
 use crate::api::warframe_client;
 use crate::enums::colors::Colors;

--- a/wondyframe/src/commands/fortuna.rs
+++ b/wondyframe/src/commands/fortuna.rs
@@ -1,6 +1,6 @@
-use log::{error, info};
 use serenity::all::CreateEmbed;
 use serenity::all::CreateEmbedFooter;
+use tracing::{error, info};
 use warframe::worldstate::{TimedEvent, queryable::OrbVallis};
 
 use crate::enums::colors::Colors;

--- a/wondyframe/src/commands/item.rs
+++ b/wondyframe/src/commands/item.rs
@@ -2,9 +2,9 @@ use std::collections::HashMap;
 
 use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
-use log::info;
 use serenity::all::CreateEmbed;
 use serenity::all::CreateEmbedFooter;
+use tracing::info;
 
 use crate::enums::colors::Colors;
 use crate::enums::thumbnail::Thumbnail;

--- a/wondyframe/src/commands/nightwave.rs
+++ b/wondyframe/src/commands/nightwave.rs
@@ -1,6 +1,6 @@
-use log::{error, info};
 use serenity::all::CreateEmbed;
 use serenity::all::CreateEmbedFooter;
+use tracing::{error, info};
 
 use crate::api::warframe_client;
 use crate::enums::colors::Colors;

--- a/wondyframe/src/commands/teshin.rs
+++ b/wondyframe/src/commands/teshin.rs
@@ -1,9 +1,9 @@
 use chrono::Duration;
 use chrono::NaiveDate;
 use chrono::Utc;
-use log::{error, info};
 use serenity::all::CreateEmbed;
 use serenity::all::CreateEmbedFooter;
+use tracing::{error, info};
 
 use crate::api::warframe_client;
 use crate::enums::colors::Colors;

--- a/wondyframe/src/main.rs
+++ b/wondyframe/src/main.rs
@@ -9,7 +9,7 @@ use crate::{
     utils::date::format_timestamp_from_utc,
 };
 use ::serenity::all::{ActivityData, ClientBuilder, Context, GatewayIntents, GuildId};
-use log::info;
+use tracing::info;
 
 use poise::{
     Framework, FrameworkOptions,
@@ -37,7 +37,7 @@ async fn on_bot_ready(ctx: &Context, ready: &serenity::Ready) {
 #[tokio::main]
 async fn main() {
     dotenv().ok();
-    env_logger::init();
+    tracing_subscriber::fmt().json().init();
     let token = var("DISCORD_TOKEN").expect("missing DISCORD_TOKEN");
     let intents = GatewayIntents::non_privileged();
 


### PR DESCRIPTION
Migrates application logging from `log` + `env_logger` to `tracing` + `tracing-subscriber`, enabling structured JSON logging and laying the groundwork for improved observability.

## Changes

- Replaced logging dependencies:
  - `log` → `tracing`
  - `env_logger` → `tracing-subscriber`
- Updated logging imports throughout the codebase:
  - `log::info` → `tracing::info`
  - `log::{error, info}` → `tracing::{error, info}`
- Switched logger initialization:
  - `env_logger::init()`
  - → `tracing_subscriber::fmt().json().init()`
- Enabled `json` and `env-filter` features for `tracing-subscriber`.

## Benefits

- Structured JSON logs suitable for centralized logging platforms.
- Improved compatibility with modern observability and tracing tooling.
- Provides a foundation for adding spans, context propagation, and distributed tracing in the future.